### PR TITLE
Set product-miniature card height to 100%

### DIFF
--- a/src/scss/core/components/product/_product-miniature.scss
+++ b/src/scss/core/components/product/_product-miniature.scss
@@ -1,6 +1,9 @@
 $component-name: product-miniature;
 
 .#{$component-name} {
+  .card {
+    height: 100%;
+  }
   & &__infos {
     position: relative;
     z-index: 90;


### PR DESCRIPTION
Set height 100% to align cards in category pages.